### PR TITLE
Gjør overskiftfeltet nullable

### DIFF
--- a/src/main/kotlin/dab/poao/nav/no/arkivering/dto/ArkiveringsPayload.kt
+++ b/src/main/kotlin/dab/poao/nav/no/arkivering/dto/ArkiveringsPayload.kt
@@ -75,7 +75,7 @@ data class Detalj(
 
 @Serializable
 data class ArkivDialogtråd(
-    val overskrift: String,
+    val overskrift: String?,
     val meldinger: List<Melding>,
     val egenskaper: List<String>,
     val indexSisteMeldingLestAvBruker: Int?,


### PR DESCRIPTION
For å kunne journalføre dialogmeldinger uten overskrift til vi finner en annen løsning på issuet